### PR TITLE
refactor: expose parsed Header fields

### DIFF
--- a/httpsignatures_test.go
+++ b/httpsignatures_test.go
@@ -507,8 +507,8 @@ func TestHSBuildSignatureString(t *testing.T) {
 			name: "Valid signature string",
 			args: args{
 				ph: Headers{
-					algorithm: "md5",
-					headers: []string{
+					Algorithm: "md5",
+					Headers: []string{
 						"(request-target)",
 						"(created)",
 						"(expires)",
@@ -517,8 +517,8 @@ func TestHSBuildSignatureString(t *testing.T) {
 						"digest",
 						"content-length",
 					},
-					created: time.Unix(1402170695, 0),
-					expires: time.Unix(1402170995, 0),
+					Created: time.Unix(1402170695, 0),
+					Expires: time.Unix(1402170995, 0),
 				},
 				r: (func() *http.Request {
 					r, _ := http.NewRequest(http.MethodPost, testHostExamplePath, strings.NewReader(testBodyExample))
@@ -544,11 +544,11 @@ func TestHSBuildSignatureString(t *testing.T) {
 			name: "Has created header with 0 value",
 			args: args{
 				ph: Headers{
-					algorithm: "md5",
-					headers: []string{
+					Algorithm: "md5",
+					Headers: []string{
 						"(created)",
 					},
-					created: time.Unix(0, 0),
+					Created: time.Unix(0, 0),
 				},
 				r: (func() *http.Request {
 					r, _ := http.NewRequest(http.MethodPost, testHostExamplePath, strings.NewReader(testBodyExample))
@@ -563,11 +563,11 @@ func TestHSBuildSignatureString(t *testing.T) {
 			name: "Has expires header with 0 value",
 			args: args{
 				ph: Headers{
-					algorithm: "sha-256",
-					headers: []string{
+					Algorithm: "sha-256",
+					Headers: []string{
 						"(expires)",
 					},
-					expires: time.Unix(0, 0),
+					Expires: time.Unix(0, 0),
 				},
 				r: (func() *http.Request {
 					r, _ := http.NewRequest(http.MethodPost, testHostExamplePath, strings.NewReader(testBodyExample))
@@ -582,8 +582,8 @@ func TestHSBuildSignatureString(t *testing.T) {
 			name: "Header with 0 length",
 			args: args{
 				ph: Headers{
-					algorithm: "md5",
-					headers: []string{
+					Algorithm: "md5",
+					Headers: []string{
 						"host",
 						"digest",
 					},
@@ -605,8 +605,8 @@ func TestHSBuildSignatureString(t *testing.T) {
 			name: "Header not found",
 			args: args{
 				ph: Headers{
-					algorithm: "md5",
-					headers: []string{
+					Algorithm: "md5",
+					Headers: []string{
 						"host",
 						"digest",
 					},
@@ -751,24 +751,24 @@ func TestHSBuildSignatureHeader(t *testing.T) {
 		{
 			name: "Signature string OK",
 			arg: Headers{
-				keyID:     "key1",
-				algorithm: "alg",
-				created:   time.Unix(1591130723, 0),
-				expires:   time.Unix(1591130723, 0),
-				headers:   []string{"digest", "host"},
-				signature: "signature",
+				KeyID:     "key1",
+				Algorithm: "alg",
+				Created:   time.Unix(1591130723, 0),
+				Expires:   time.Unix(1591130723, 0),
+				Headers:   []string{"digest", "host"},
+				Signature: "signature",
 			},
 			want: `keyId="key1",algorithm="alg",headers="digest host",signature="signature"`,
 		},
 		{
 			name: "Signature string with created & expires OK",
 			arg: Headers{
-				keyID:     "key2",
-				algorithm: "alg",
-				created:   time.Unix(1591130723, 0),
-				expires:   time.Unix(1591130723, 0),
-				headers:   []string{"(created)", "(expires)"},
-				signature: "signature",
+				KeyID:     "key2",
+				Algorithm: "alg",
+				Created:   time.Unix(1591130723, 0),
+				Expires:   time.Unix(1591130723, 0),
+				Headers:   []string{"(created)", "(expires)"},
+				Signature: "signature",
 			},
 			want: `keyId="key2",algorithm="alg",created=1591130723,expires=1591130723,headers="(created) (expires)",` +
 				`signature="signature"`,

--- a/parser.go
+++ b/parser.go
@@ -34,12 +34,12 @@ const (
 
 // Headers Signature headers & params
 type Headers struct {
-	keyID     string    // REQUIRED
-	algorithm string    // RECOMMENDED
-	created   time.Time // RECOMMENDED
-	expires   time.Time // OPTIONAL (Not implemented: "Subsecond precision is allowed using decimal notation.")
-	headers   []string  // OPTIONAL
-	signature string    // REQUIRED
+	KeyID     string    // REQUIRED
+	Algorithm string    // RECOMMENDED
+	Created   time.Time // RECOMMENDED
+	Expires   time.Time // OPTIONAL (Not implemented: "Subsecond precision is allowed using decimal notation.")
+	Headers   []string  // OPTIONAL
+	Signature string    // REQUIRED
 }
 
 // DigestHeader Digest header parsed into params (alg & digest)
@@ -355,21 +355,21 @@ func (p *Parser) setKeyValue() *ErrParser {
 	p.params[k] = true
 
 	if k == "keyId" {
-		p.headers.keyID = string(p.value)
+		p.headers.KeyID = string(p.value)
 	} else if k == "algorithm" {
-		p.headers.algorithm = string(p.value)
+		p.headers.Algorithm = string(p.value)
 	} else if k == "headers" {
-		p.headers.headers = strings.Fields(string(p.value))
+		p.headers.Headers = strings.Fields(string(p.value))
 	} else if k == "signature" {
-		p.headers.signature = string(p.value)
+		p.headers.Signature = string(p.value)
 	} else if k == "created" {
 		var err error
-		if p.headers.created, err = p.intToTime(p.value); err != nil {
+		if p.headers.Created, err = p.intToTime(p.value); err != nil {
 			return &ErrParser{"wrong 'created' param value", err}
 		}
 	} else if k == "expires" {
 		var err error
-		if p.headers.expires, err = p.intToTime(p.value); err != nil {
+		if p.headers.Expires, err = p.intToTime(p.value); err != nil {
 			return &ErrParser{"wrong 'expires' param value", err}
 		}
 	}
@@ -410,14 +410,14 @@ func (p *Parser) setDigest() *ErrParser {
 
 // VerifySignatureFields verify required fields
 func (p *Parser) VerifySignatureFields() *ErrParser {
-	if p.headers.keyID == "" {
+	if p.headers.KeyID == "" {
 		return &ErrParser{
 			"keyId is not set in header",
 			nil,
 		}
 	}
 
-	if p.headers.signature == "" {
+	if p.headers.Signature == "" {
 		return &ErrParser{
 			"signature is not set in header",
 			nil,

--- a/parser_test.go
+++ b/parser_test.go
@@ -13,12 +13,12 @@ const testValidSignatureHeader = `keyId="Test",algorithm="rsa-sha256",created=14
 	`xpeIq8knRmPnYePbF5MOkR0Zkly4zKH7s1dE="`
 
 var testValidParsedSignatureHeader = Headers{
-	keyID:     "Test",
-	algorithm: "rsa-sha256",
-	created:   time.Unix(1402170695, 0),
-	expires:   time.Unix(1402170699, 0),
-	headers:   []string{"(request-target)", "(created)", "(expires)", "host", "date", "digest", "content-length"},
-	signature: "vSdrb+dS3EceC9bcwHSo4MlyKS59iFIrhgYkz8+oVLEEzmYZZvRs8rgOp+63LEM3v+MFHB32NfpB2bEKBIvB1q52LaEUHFv120V01" +
+	KeyID:     "Test",
+	Algorithm: "rsa-sha256",
+	Created:   time.Unix(1402170695, 0),
+	Expires:   time.Unix(1402170699, 0),
+	Headers:   []string{"(request-target)", "(created)", "(expires)", "host", "date", "digest", "content-length"},
+	Signature: "vSdrb+dS3EceC9bcwHSo4MlyKS59iFIrhgYkz8+oVLEEzmYZZvRs8rgOp+63LEM3v+MFHB32NfpB2bEKBIvB1q52LaEUHFv120V01" +
 		"IL+TAD48XaERZFukWgHoBTLMhYS2Gb51gWxpeIq8knRmPnYePbF5MOkR0Zkly4zKH7s1dE=",
 }
 
@@ -78,7 +78,7 @@ func TestParserParseSingleFields(t *testing.T) {
 				header: `keyId="v1"`,
 			},
 			want: Headers{
-				keyID: "v1",
+				KeyID: "v1",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -89,7 +89,7 @@ func TestParserParseSingleFields(t *testing.T) {
 				header: `algorithm="v2"`,
 			},
 			want: Headers{
-				algorithm: "v2",
+				Algorithm: "v2",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -100,7 +100,7 @@ func TestParserParseSingleFields(t *testing.T) {
 				header: `headers="(request-target) (created)" `,
 			},
 			want: Headers{
-				headers: []string{"(request-target)", "(created)"},
+				Headers: []string{"(request-target)", "(created)"},
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -111,7 +111,7 @@ func TestParserParseSingleFields(t *testing.T) {
 				header: `signature="test" `,
 			},
 			want: Headers{
-				signature: "test",
+				Signature: "test",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -123,12 +123,12 @@ func TestParserParseSingleFields(t *testing.T) {
 					`"v5"`,
 			},
 			want: Headers{
-				keyID:     "v1",
-				algorithm: "v2",
-				created:   time.Unix(1402170695, 0),
-				expires:   time.Unix(1402170699, 0),
-				headers:   []string{"v-3", "v-4"},
-				signature: "v5",
+				KeyID:     "v1",
+				Algorithm: "v2",
+				Created:   time.Unix(1402170695, 0),
+				Expires:   time.Unix(1402170699, 0),
+				Headers:   []string{"v-3", "v-4"},
+				Signature: "v5",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -140,12 +140,12 @@ func TestParserParseSingleFields(t *testing.T) {
 					`v-3 v-4  ", signature="v5"   `,
 			},
 			want: Headers{
-				keyID:     "v1",
-				algorithm: "v2",
-				created:   time.Unix(1402170695, 0),
-				expires:   time.Unix(1402170699, 0),
-				headers:   []string{"v-3", "v-4"},
-				signature: "v5",
+				KeyID:     "v1",
+				Algorithm: "v2",
+				Created:   time.Unix(1402170695, 0),
+				Expires:   time.Unix(1402170699, 0),
+				Headers:   []string{"v-3", "v-4"},
+				Signature: "v5",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -157,12 +157,12 @@ func TestParserParseSingleFields(t *testing.T) {
 					`"s1"`,
 			},
 			want: Headers{
-				keyID:     "k1",
-				algorithm: "a1",
-				created:   time.Unix(1592157709, 0),
-				expires:   time.Unix(1592157709, 0),
-				headers:   []string{"h1", "h2"},
-				signature: "s1",
+				KeyID:     "k1",
+				Algorithm: "a1",
+				Created:   time.Unix(1592157709, 0),
+				Expires:   time.Unix(1592157709, 0),
+				Headers:   []string{"h1", "h2"},
+				Signature: "s1",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -285,7 +285,7 @@ func TestParserParseCreatedExpires(t *testing.T) {
 				header: `created=1402170695`,
 			},
 			want: Headers{
-				created: time.Unix(1402170695, 0),
+				Created: time.Unix(1402170695, 0),
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -296,7 +296,7 @@ func TestParserParseCreatedExpires(t *testing.T) {
 				header: `expires=1402170699`,
 			},
 			want: Headers{
-				expires: time.Unix(1402170699, 0),
+				Expires: time.Unix(1402170699, 0),
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -479,7 +479,7 @@ func TestParserParseAmbiguousParams(t *testing.T) {
 				header: `keyId="v1",ambiguous="v2",digest="v3"`,
 			},
 			want: Headers{
-				keyID: "v1",
+				KeyID: "v1",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",
@@ -587,7 +587,7 @@ func TestNotSpecifiedHeadersParams(t *testing.T) {
 				header: `keyId="v1"`,
 			},
 			want: Headers{
-				keyID: "v1",
+				KeyID: "v1",
 			},
 			wantErrType: testErrParserType,
 			wantErrMsg:  "",


### PR DESCRIPTION
This PR exposes the parsed `Header` fields.

**Motivation**

Additional validations at the application layer. In particular, we have a use case where the same `keyId` should be referenced in a custom header that is included in the signature's covered content.

Signed-off-by: George Aristy <george.aristy@gmail.com>